### PR TITLE
Switch to thiserror to avoid duplicate error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ mailparse = "0.13.4"
 rfc2047-decoder = "0.1.2"
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 tar = "0.4.35"
+thiserror = "1.0.30"
 xz = { version = "0.1.0", optional = true }
 zip = { version = "0.6.0", default-features = false, features = ["bzip2", "deflate", "time"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,71 +1,31 @@
-use std::{error, fmt, io};
+use std::io;
 
 use mailparse::MailParseError;
+use thiserror::Error;
 use zip::result::ZipError;
 
 /// The error type
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// I/O error
-    Io(io::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
     /// mail parse error
-    MailParse(MailParseError),
+    #[error(transparent)]
+    MailParse(#[from] MailParseError),
     /// Zip parse error
-    Zip(ZipError),
+    #[error(transparent)]
+    Zip(#[from] ZipError),
     /// Metadata field not found
+    #[error("metadata field {0} not found")]
     FieldNotFound(&'static str),
     /// Unknown distribution type
+    #[error("unknown distribution type")]
     UnknownDistributionType,
     /// Metadata file not found
+    #[error("metadata file not found")]
     MetadataNotFound,
     /// Multiple metadata files found
+    #[error("found multiple metadata files: {0:?}")]
     MultipleMetadataFiles(Vec<String>),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Io(err) => err.fmt(f),
-            Error::MailParse(err) => err.fmt(f),
-            Error::Zip(err) => err.fmt(f),
-            Error::FieldNotFound(key) => write!(f, "metadata field {} not found", key),
-            Error::UnknownDistributionType => write!(f, "unknown distribution type"),
-            Error::MetadataNotFound => write!(f, "metadata file not found"),
-            Error::MultipleMetadataFiles(files) => {
-                write!(f, "found multiple metadata files: {:?}", files)
-            }
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Error::Io(err) => Some(err),
-            Error::MailParse(err) => Some(err),
-            Error::Zip(err) => Some(err),
-            Error::FieldNotFound(_)
-            | Error::UnknownDistributionType
-            | Error::MetadataNotFound
-            | Error::MultipleMetadataFiles(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<MailParseError> for Error {
-    fn from(err: MailParseError) -> Self {
-        Self::MailParse(err)
-    }
-}
-
-impl From<ZipError> for Error {
-    fn from(err: ZipError) -> Self {
-        Self::Zip(err)
-    }
 }


### PR DESCRIPTION
Currently, wrapped errors get printed twice. E.g. i see `invalid Zip archive: Could not find central directory end` and then `invalid Zip archive: Could not find central directory end` in the error chain. This PR fixes this by using thiserror. The manual solution is implemented in #5