### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/PyO3/python-pkginfo-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bzip2 = { version = "0.4.2", optional = true }
+bzip2 = { version = "0.4.4", optional = true }
 flate2 = "1.0.20"
 fs-err = "2.6.0"
 mailparse = "0.13.4"


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)