### PR TITLE
add license-expression and license-file support

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -52,9 +52,9 @@ pub struct Metadata {
     /// An SPDX expression indicating the license covering the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
     pub license_expression: Option<String>,
-    /// The path to a file containing the text of the license covering the distribution.
+    /// Paths to files containing the text of the licenses covering the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
-    pub license_file: Option<String>,
+    pub license_files: Vec<String>,
     /// Each entry is a string giving a single classification value for the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
     pub classifiers: Vec<String>,
@@ -159,7 +159,7 @@ impl Metadata {
         let author_email = get_first_value("Author-email");
         let license = get_first_value("License");
         let license_expression = get_first_value("License-Expression");
-        let license_file = get_first_value("License-File");
+        let license_files = get_all_values("License-File");
         let classifiers = get_all_values("Classifier");
         let requires_dist = get_all_values("Requires-Dist");
         let provides_dist = get_all_values("Provides-Dist");
@@ -187,7 +187,7 @@ impl Metadata {
             author_email,
             license,
             license_expression,
-            license_file,
+            license_files,
             classifiers,
             requires_dist,
             provides_dist,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -52,6 +52,9 @@ pub struct Metadata {
     /// An SPDX expression indicating the license covering the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
     pub license_expression: Option<String>,
+    /// The path to a file containing the text of the license covering the distribution.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub license_file: Option<String>,
     /// Each entry is a string giving a single classification value for the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
     pub classifiers: Vec<String>,
@@ -156,6 +159,7 @@ impl Metadata {
         let author_email = get_first_value("Author-email");
         let license = get_first_value("License");
         let license_expression = get_first_value("License-Expression");
+        let license_file = get_first_value("License-File");
         let classifiers = get_all_values("Classifier");
         let requires_dist = get_all_values("Requires-Dist");
         let provides_dist = get_all_values("Provides-Dist");
@@ -183,6 +187,7 @@ impl Metadata {
             author_email,
             license,
             license_expression,
+            license_file,
             classifiers,
             requires_dist,
             provides_dist,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -46,9 +46,12 @@ pub struct Metadata {
     /// A string containing the author’s e-mail address. It can contain a name and e-mail address in the legal forms for a RFC-822 `From:` header.
     #[cfg_attr(feature = "serde", serde(default))]
     pub author_email: Option<String>,
-    /// Text indicating the license covering the distribution where the license is not a selection from the `License` Trove classifiers.
+    /// Text indicating the license covering the distribution where the license is not a selection from the `License` Trove classifiers or an SPDX license expression.
     #[cfg_attr(feature = "serde", serde(default))]
     pub license: Option<String>,
+    /// An SPDX expression indicating the license covering the distribution.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub license_expression: Option<String>,
     /// Each entry is a string giving a single classification value for the distribution.
     #[cfg_attr(feature = "serde", serde(default))]
     pub classifiers: Vec<String>,
@@ -152,6 +155,7 @@ impl Metadata {
         let author = get_first_value("Author");
         let author_email = get_first_value("Author-email");
         let license = get_first_value("License");
+        let license_expression = get_first_value("License-Expression");
         let classifiers = get_all_values("Classifier");
         let requires_dist = get_all_values("Requires-Dist");
         let provides_dist = get_all_values("Provides-Dist");
@@ -178,6 +182,7 @@ impl Metadata {
             author,
             author_email,
             license,
+            license_expression,
             classifiers,
             requires_dist,
             provides_dist,


### PR DESCRIPTION
I'm not sure this is the right way to accomplish this. These fields are in the draft PEP 639 but they're [already in use](https://github.com/pypa/hatch/pull/576).

I also considered keeping the raw mail headers list around so code using this library could get headers that this library doesn't understand, but it would involve either keeping two copies of everything because `Metadata` is owned by `Distribution` or reworking the `Metadata` API so it doesn't own all the metadata values.