### PR TITLE
Test minimal versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,16 @@ jobs:
       - run: cargo test
       - run: cargo test --all-features
 
+  test-direct-minimal-versions:
+    name: Test Direct Minimal Versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly update -Z minimal-versions
+      - run: cargo +stable test
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add testing for `-Z minimal-versions` in CI in preparation for https://github.com/PyO3/python-pkginfo-rs/pull/14.

This does not add `-Zdirect-minimal-versions` since it fails to resolve:

```
error: failed to select a version for `flate2`.
    ... required by package `zip v1.1.0`
    ... which satisfies dependency `zip = "^1.0.0"` of package `python-pkginfo v0.6.1 (/home/konsti/projects/python-pkginfo-rs)`
versions that meet the requirements `^1.0.28` are: 1.0.30, 1.0.29, 1.0.28

all possible versions conflict with previously selected packages.

  previously selected package `flate2 v1.0.20`
    ... which satisfies dependency `flate2 = "^1.0.20"` of package `python-pkginfo v0.6.1 (/home/konsti/projects/python-pkginfo-rs)`

failed to select a version for `flate2` which could resolve this conflict
```

It also does not test with all features, since pulling in the deprecated formats pulls in filetime 0.1.0 which fails to compile.