### PR TITLE
Release 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "python-pkginfo"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-pkginfo"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["messense <messense@icloud.com>"]
 edition = "2021"
 description = "Parse Python package metadata from sdist and bdists and etc."


### PR DESCRIPTION
Relax `zip` down to 0.6 for https://github.com/PyO3/python-pkginfo-rs/issues/13