### PR TITLE
Depend directly on xz2 rather than the xz alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
  "serde_json",
  "tar",
  "thiserror",
- "xz",
+ "xz2",
  "zip",
 ]
 
@@ -656,15 +656,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
-]
-
-[[package]]
-name = "xz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
-dependencies = [
- "xz2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rfc2047-decoder = "1.0.5"
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 tar = "0.4.41"
 thiserror = "1.0.63"
-xz = { version = "0.1.0", optional = true }
+xz = { package = "xz2", version = "0.1.7", optional = true }
 zip = { version = ">=0.6,<2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]


### PR DESCRIPTION
See https://crates.io/crates/xz: “It's currently an alias of xz2 crate.”

This just removes the unnecessary indirection through the `xz` crate, without renaming the implicit `xz` feature associated with the optional dependency.