### PR TITLE
Update mailparse to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "mailparse"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+checksum = "60819a97ddcb831a5614eb3b0174f3620e793e97e09195a395bfa948fd68ed2f"
 dependencies = [
  "charset",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/PyO3/python-pkginfo-rs"
 bzip2 = { version = "0.4.4", optional = true }
 flate2 = "1.0.33"
 fs-err = "3.0.0"
-mailparse = "0.15"
+mailparse = "0.16"
 rfc2047-decoder = "1.0.6"
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 tar = "0.4.41"


### PR DESCRIPTION
The change that triggered the SemVer-incompatible version bump was https://github.com/staktrace/mailparse/commit/b69d3bc0decd7e55078e09f5b32b926a3f23bc17; discussion appears in https://github.com/staktrace/mailparse/issues/127.

I confirmed that `cargo test` still passes.